### PR TITLE
transformer_moe_layer: Fix Runtime error

### DIFF
--- a/examples/deepspeed/moe_e/user/modules/transformer_moe_layer.py
+++ b/examples/deepspeed/moe_e/user/modules/transformer_moe_layer.py
@@ -49,6 +49,14 @@ DEFAULT_MAX_TARGET_POSITIONS = 1024
 
 DEFAULT_MIN_PARAMS_TO_WRAP = int(1e8)
 
+def get_device():
+    import deepspeed
+
+    def _get_version(_version):
+        return tuple(map(int, _version.split('.')))
+    if _get_version(deepspeed.__version__) >= _get_version("0.15.0"):
+        return "cuda"
+    return "cpu"
 
 class TransformerEncoderLayer_MOE(nn.Module):
     """Encoder layer block.
@@ -93,7 +101,8 @@ class TransformerEncoderLayer_MOE(nn.Module):
         self.experts = None
         if (index + 1) % 2 == 0:
             from deepspeed.moe.layer import MoE
-            self.expert_counts = torch.zeros(1, args.num_experts, dtype=torch.int64).to('cpu')
+            dev = get_device()
+            self.expert_counts = torch.zeros(1, args.num_experts, dtype=torch.int64).to(dev)
             self.fc1 = self.build_fc1(
                 self.embed_dim,
                 args.encoder_ffn_embed_dim,
@@ -340,7 +349,8 @@ class TransformerDecoderLayer_MOE(nn.Module):
         self.experts = None
         if (index + 1) % 2 == 0:
             from deepspeed.moe.layer import MoE
-            self.expert_counts = torch.zeros(1, args.num_experts, dtype=torch.int64).to('cpu')
+            dev = get_device()
+            self.expert_counts = torch.zeros(1, args.num_experts, dtype=torch.int64).to(dev)
             self.fc1 = self.build_fc1(
                 self.embed_dim,
                 args.encoder_ffn_embed_dim,


### PR DESCRIPTION
Fix the issue "[rank0]: RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!"
On DeepSpeed library 0.15.0, the commit 7260890452eb89185f9ab1e09550938f78ea91db changed the return output tensor exp_counts from 'cpu' to device when calling deepspeed.moe.layer.MoE()
This change reduces cpu host overhead when using moe. The device type of self.expert_counts tensor in Fairseq transformer_moe_layer module needs to be changed from cpu to cuda, for ds library >= 0.15.0

Fixes https://ontrack-internal.amd.com/browse/SWDEV-485020
